### PR TITLE
Rename package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "SwedbankPay/swedbank-pay-sdk-php",
+  "name": "swedbank-pay/swedbank-pay-sdk-php",
   "type": "library",
   "version": "3.0.0",
   "description": "The Swedbank Pay SDK for PHP simplifies integrations against Swedbank Pay's API Platform by providing native PHP interface towards the REST API.",


### PR DESCRIPTION
Rename the package from `SwedbankPay/swedbank-pay-sdk-php` to `swedbank-pay/swedbank-pay-sdk-php` according to Packagist's own warning:

> The package name SwedbankPay/swedbank-pay-sdk-php is invalid,
> it should not contain uppercase characters. We suggest using
> swedbank-pay/swedbank-pay-sdk-php instead.