### PR TITLE
Implemented Metadata feature

### DIFF
--- a/src/SwedbankPay/Api/Service/Payment/Resource/Request/Data/MetadataInterface.php
+++ b/src/SwedbankPay/Api/Service/Payment/Resource/Request/Data/MetadataInterface.php
@@ -36,5 +36,5 @@ interface MetadataInterface extends ResourceInterface
      * @param mixed $value
      * @return $this
      */
-    public function unsData($key);
+    public function unsetData($key);
 }

--- a/src/SwedbankPay/Api/Service/Payment/Resource/Request/Data/MetadataInterface.php
+++ b/src/SwedbankPay/Api/Service/Payment/Resource/Request/Data/MetadataInterface.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SwedbankPay\Api\Service\Payment\Resource\Request\Data;
+
+use SwedbankPay\Api\Service\Data\ResourceInterface;
+
+/**
+ * Payment order metadata interface
+ *
+ * @api
+ */
+interface MetadataInterface extends ResourceInterface
+{
+    const KEY1 = 'key1';
+    const KEY2 = 'key2';
+    const KEY3 = 'key3';
+    const KEY4 = 'key4';
+
+    /**
+     * Get Data.
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public function getData($key);
+
+    /**
+     * Set Data.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return $this
+     */
+    public function setData($key, $value);
+
+    /**
+     * @return string
+     */
+    public function getKey1();
+
+    /**
+     * @param string $key1
+     * @return $this
+     */
+    public function setKey1($key1);
+
+    /**
+     * @return int
+     */
+    public function getKey2();
+
+    /**
+     * @param int $key2
+     * @return $this
+     */
+    public function setKey2($key2);
+
+    /**
+     * @return float
+     */
+    public function getKey3();
+
+    /**
+     * @param float $key3
+     * @return $this
+     */
+    public function setKey3($key3);
+
+    /**
+     * @return mixed
+     */
+    public function getKey4();
+
+    /**
+     * @param mixed $key4
+     * @return $this
+     */
+    public function setKey4($key4);
+}

--- a/src/SwedbankPay/Api/Service/Payment/Resource/Request/Data/MetadataInterface.php
+++ b/src/SwedbankPay/Api/Service/Payment/Resource/Request/Data/MetadataInterface.php
@@ -11,10 +11,6 @@ use SwedbankPay\Api\Service\Data\ResourceInterface;
  */
 interface MetadataInterface extends ResourceInterface
 {
-    const KEY1 = 'key1';
-    const KEY2 = 'key2';
-    const KEY3 = 'key3';
-    const KEY4 = 'key4';
 
     /**
      * Get Data.
@@ -34,46 +30,11 @@ interface MetadataInterface extends ResourceInterface
     public function setData($key, $value);
 
     /**
-     * @return string
-     */
-    public function getKey1();
-
-    /**
-     * @param string $key1
+     * Unset Data.
+     *
+     * @param string $key
+     * @param mixed $value
      * @return $this
      */
-    public function setKey1($key1);
-
-    /**
-     * @return int
-     */
-    public function getKey2();
-
-    /**
-     * @param int $key2
-     * @return $this
-     */
-    public function setKey2($key2);
-
-    /**
-     * @return float
-     */
-    public function getKey3();
-
-    /**
-     * @param float $key3
-     * @return $this
-     */
-    public function setKey3($key3);
-
-    /**
-     * @return mixed
-     */
-    public function getKey4();
-
-    /**
-     * @param mixed $key4
-     * @return $this
-     */
-    public function setKey4($key4);
+    public function unsData($key);
 }

--- a/src/SwedbankPay/Api/Service/Payment/Resource/Request/Data/PaymentRequestInterface.php
+++ b/src/SwedbankPay/Api/Service/Payment/Resource/Request/Data/PaymentRequestInterface.php
@@ -12,6 +12,8 @@ use SwedbankPay\Api\Service\Payment\Resource\Data\PaymentInterface;
 interface PaymentRequestInterface extends PaymentInterface
 {
     const PREFILL_INFO = 'prefill_info';
+    const METADATA = 'metadata';
+
 
     /**
      * @return PrefillInfoInterface
@@ -23,4 +25,19 @@ interface PaymentRequestInterface extends PaymentInterface
      * @return $this
      */
     public function setPrefillInfo($prefillInfo);
+
+    /**
+     * Get Metadata can be used to store data associated to a payment.
+     *
+     * @return MetadataInterface
+     */
+    public function getMetadata();
+
+    /**
+     * Set Metadata can be used to store data associated to a payment.
+     *
+     * @param MetadataInterface $metadata
+     * @return $this
+     */
+    public function setMetadata($metadata);
 }

--- a/src/SwedbankPay/Api/Service/Payment/Resource/Request/Metadata.php
+++ b/src/SwedbankPay/Api/Service/Payment/Resource/Request/Metadata.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SwedbankPay\Api\Service\Payment\Resource\Request;
+
+use SwedbankPay\Api\Service\Payment\Resource\Request\Data\MetadataInterface;
+use SwedbankPay\Api\Service\Resource;
+
+/**
+ * Payment metadata data object
+ */
+class Metadata extends Resource implements MetadataInterface
+{
+    /**
+     * Get Data.
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public function getData($key)
+    {
+        return $this->offsetGet($key);
+    }
+
+    /**
+     * Set Data.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return $this
+     */
+    public function setData($key, $value)
+    {
+        return $this->offsetSet($key, $value);
+    }
+
+    /**
+     * @return string
+     */
+    public function getKey1()
+    {
+        return $this->offsetGet(self::KEY1);
+    }
+
+    /**
+     * @param string $key1
+     * @return $this
+     */
+    public function setKey1($key1)
+    {
+        return $this->offsetSet(self::KEY1, $key1);
+    }
+
+    /**
+     * @return int
+     */
+    public function getKey2()
+    {
+        return $this->offsetGet(self::KEY2);
+    }
+
+    /**
+     * @param int $key2
+     * @return $this
+     */
+    public function setKey2($key2)
+    {
+        return $this->offsetSet(self::KEY2, $key2);
+    }
+
+    /**
+     * @return float
+     */
+    public function getKey3()
+    {
+        return $this->offsetGet(self::KEY3);
+    }
+
+    /**
+     * @param float $key3
+     * @return $this
+     */
+    public function setKey3($key3)
+    {
+        return $this->offsetSet(self::KEY3, $key3);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getKey4()
+    {
+        return $this->offsetGet(self::KEY4);
+    }
+
+    /**
+     * @param mixed $key4
+     * @return $this
+     */
+    public function setKey4($key4)
+    {
+        return $this->offsetSet(self::KEY4, $key4);
+    }
+}

--- a/src/SwedbankPay/Api/Service/Payment/Resource/Request/Metadata.php
+++ b/src/SwedbankPay/Api/Service/Payment/Resource/Request/Metadata.php
@@ -40,7 +40,7 @@ class Metadata extends Resource implements MetadataInterface
      * @param mixed $value
      * @return $this
      */
-    public function unsData($key)
+    public function unsetData($key)
     {
         return $this->offsetUnset($key);
     }

--- a/src/SwedbankPay/Api/Service/Payment/Resource/Request/Metadata.php
+++ b/src/SwedbankPay/Api/Service/Payment/Resource/Request/Metadata.php
@@ -34,70 +34,14 @@ class Metadata extends Resource implements MetadataInterface
     }
 
     /**
-     * @return string
-     */
-    public function getKey1()
-    {
-        return $this->offsetGet(self::KEY1);
-    }
-
-    /**
-     * @param string $key1
+     * Unset Data.
+     *
+     * @param string $key
+     * @param mixed $value
      * @return $this
      */
-    public function setKey1($key1)
+    public function unsData($key)
     {
-        return $this->offsetSet(self::KEY1, $key1);
-    }
-
-    /**
-     * @return int
-     */
-    public function getKey2()
-    {
-        return $this->offsetGet(self::KEY2);
-    }
-
-    /**
-     * @param int $key2
-     * @return $this
-     */
-    public function setKey2($key2)
-    {
-        return $this->offsetSet(self::KEY2, $key2);
-    }
-
-    /**
-     * @return float
-     */
-    public function getKey3()
-    {
-        return $this->offsetGet(self::KEY3);
-    }
-
-    /**
-     * @param float $key3
-     * @return $this
-     */
-    public function setKey3($key3)
-    {
-        return $this->offsetSet(self::KEY3, $key3);
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getKey4()
-    {
-        return $this->offsetGet(self::KEY4);
-    }
-
-    /**
-     * @param mixed $key4
-     * @return $this
-     */
-    public function setKey4($key4)
-    {
-        return $this->offsetSet(self::KEY4, $key4);
+        return $this->offsetUnset($key);
     }
 }

--- a/src/SwedbankPay/Api/Service/Payment/Resource/Request/Payment.php
+++ b/src/SwedbankPay/Api/Service/Payment/Resource/Request/Payment.php
@@ -7,6 +7,7 @@ use SwedbankPay\Api\Service\Payment\Resource\Request\Data\PayeeInfoInterface;
 use SwedbankPay\Api\Service\Payment\Resource\Request\Data\PrefillInfoInterface;
 use SwedbankPay\Api\Service\Payment\Resource\Request\Data\UrlInterface;
 use SwedbankPay\Api\Service\Payment\Resource\Request\Data\PaymentRequestInterface;
+use SwedbankPay\Api\Service\Payment\Resource\Request\Data\MetadataInterface;
 use SwedbankPay\Api\Service\Resource\Request as RequestResource;
 
 /**
@@ -65,5 +66,26 @@ class Payment extends RequestResource implements PaymentRequestInterface
     public function setPrefillInfo($prefillInfo)
     {
         return $this->offsetSet(self::PREFILL_INFO, $prefillInfo);
+    }
+
+    /**
+     * Get Metadata can be used to store data associated to a payment.
+     *
+     * @return MetadataInterface
+     */
+    public function getMetadata()
+    {
+        return $this->offsetGet(self::METADATA);
+    }
+
+    /**
+     * Set Metadata can be used to store data associated to a payment.
+     *
+     * @param MetadataInterface $metadata
+     * @return $this
+     */
+    public function setMetadata($metadata)
+    {
+        return $this->offsetSet(self::METADATA, $metadata);
     }
 }

--- a/tests/CardPaymentTest.php
+++ b/tests/CardPaymentTest.php
@@ -11,6 +11,7 @@ use SwedbankPay\Api\Service\Creditcard\Resource\Request\PaymentPurchase;
 use SwedbankPay\Api\Service\Creditcard\Resource\Request\PaymentVerify;
 use SwedbankPay\Api\Service\Payment\Resource\Collection\PricesCollection;
 use SwedbankPay\Api\Service\Payment\Resource\Collection\Item\PriceItem;
+use SwedbankPay\Api\Service\Payment\Resource\Request\Metadata;
 use SwedbankPay\Api\Service\Creditcard\Resource\Request\PaymentPayeeInfo;
 
 use SwedbankPay\Api\Service\Data\ResponseInterface as ResponseServiceInterface;
@@ -62,6 +63,9 @@ class CardPaymentTest extends TestCase
             ->setRejectAuthenticationStatusA(false)
             ->setRejectAuthenticationStatusU(false);
 
+        $metadata = new Metadata();
+        $metadata->setData('order_id', 'or-123456');
+
         $payment = new PaymentPurchase();
         $payment->setOperation('Purchase')
             ->setIntent('Authorization')
@@ -74,7 +78,8 @@ class CardPaymentTest extends TestCase
             ->setPayerReference($this->generateRandomString(30))
             ->setUrls($url)
             ->setPayeeInfo($payeeInfo)
-            ->setPrices($prices);
+            ->setPrices($prices)
+            ->setMetadata($metadata);
 
         $paymentObject = new PaymentPurchaseObject();
         $paymentObject->setPayment($payment);

--- a/tests/InvoicePaymentTest.php
+++ b/tests/InvoicePaymentTest.php
@@ -10,6 +10,7 @@ use SwedbankPay\Api\Service\Invoice\Transaction\Resource\Request\Consumer;
 use SwedbankPay\Api\Service\Invoice\Transaction\Resource\Request\Transaction;
 use SwedbankPay\Api\Service\Payment\Resource\Collection\PricesCollection;
 use SwedbankPay\Api\Service\Payment\Resource\Collection\Item\PriceItem;
+use SwedbankPay\Api\Service\Payment\Resource\Request\Metadata;
 use SwedbankPay\Api\Service\Invoice\Resource\Request\PaymentPayeeInfo;
 use SwedbankPay\Api\Service\Invoice\Resource\Request\PaymentUrl;
 use SwedbankPay\Api\Service\Invoice\Resource\Request\Payment;
@@ -54,6 +55,9 @@ class InvoicePaymentTest extends TestCase
         $prices = new PricesCollection();
         $prices->addItem($price);
 
+        $metadata = new Metadata();
+        $metadata->setData('order_id', 'or-123456');
+
         $payment = new Payment();
         $payment->setOperation('FinancingConsumer')
             ->setIntent('Authorization')
@@ -63,7 +67,8 @@ class InvoicePaymentTest extends TestCase
             ->setLanguage('sv-SE')
             ->setUrls($url)
             ->setPayeeInfo($payeeInfo)
-            ->setPrices($prices);
+            ->setPrices($prices)
+            ->setMetadata($metadata);
 
         $invoice = new Invoice();
         $invoice->setInvoiceType('PayExFinancingSe');

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use SwedbankPay\Api\Service\Payment\Resource\Request\Metadata;
+
+class MetadataTest extends TestCase
+{
+    public function testMetadata()
+    {
+        $metadata = new Metadata();
+        $metadata->setData('order_id', 'or-123456');
+
+        $data = json_decode($metadata->__toJson(), true);
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('orderId', $data);
+
+        $data = $metadata->__toArray();
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('order_id', $data);
+
+        $data = $metadata->getData('order_id');
+        $this->assertEquals('or-123456', $data);
+    }
+}

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -19,5 +19,8 @@ class MetadataTest extends TestCase
 
         $data = $metadata->getData('order_id');
         $this->assertEquals('or-123456', $data);
+
+        $metadata->unsetData('order_id');
+        $this->assertNull($metadata->getData('order_id'));
     }
 }

--- a/tests/MobilePayPaymentTest.php
+++ b/tests/MobilePayPaymentTest.php
@@ -4,6 +4,7 @@
 use SwedbankPay\Api\Client\Client;
 use SwedbankPay\Api\Service\Payment\Resource\Collection\PricesCollection;
 use SwedbankPay\Api\Service\Payment\Resource\Collection\Item\PriceItem;
+use SwedbankPay\Api\Service\Payment\Resource\Request\Metadata;
 use SwedbankPay\Api\Service\MobilePay\Request\Purchase;
 
 use SwedbankPay\Api\Service\MobilePay\Resource\Request\PaymentPayeeInfo;
@@ -109,6 +110,9 @@ class MobilePayPaymentTest extends TestCase
         $prices = new PricesCollection();
         $prices->addItem($price);
 
+        $metadata = new Metadata();
+        $metadata->setData('order_id', 'or-123456');
+
         $payment = new Payment();
         $payment->setOperation('Purchase')
             ->setIntent('Authorization')
@@ -120,7 +124,8 @@ class MobilePayPaymentTest extends TestCase
             ->setPayeeInfo($payeeInfo)
             ->setPrefillInfo($prefillInfo)
             ->setPrices($prices)
-            ->setPayerReference(uniqid());
+            ->setPayerReference(uniqid())
+            ->setMetadata($metadata);
 
         $paymentObject = new PaymentObject();
         $paymentObject->setPayment($payment)

--- a/tests/SwishPaymentTest.php
+++ b/tests/SwishPaymentTest.php
@@ -2,6 +2,7 @@
 
 use SwedbankPay\Api\Service\Payment\Resource\Collection\PricesCollection;
 use SwedbankPay\Api\Service\Payment\Resource\Collection\Item\PriceItem;
+use SwedbankPay\Api\Service\Payment\Resource\Request\Metadata;
 use SwedbankPay\Api\Service\Swish\Request\Purchase;
 use SwedbankPay\Api\Service\Swish\Resource\Request\PaymentPayeeInfo;
 use SwedbankPay\Api\Service\Swish\Resource\Request\PaymentPrefillInfo;
@@ -55,6 +56,9 @@ class SwishPaymentTest extends TestCase
         $prices = new PricesCollection();
         $prices->addItem($price);
 
+        $metadata = new Metadata();
+        $metadata->setData('order_id', 'or-123456');
+
         $payment = new Payment();
         $payment->setOperation('Purchase')
             ->setIntent('Sale')
@@ -66,7 +70,8 @@ class SwishPaymentTest extends TestCase
             ->setPayeeInfo($payeeInfo)
             ->setPrefillInfo($prefillInfo)
             ->setSwish($swish)
-            ->setPrices($prices);
+            ->setPrices($prices)
+            ->setMetadata($metadata);
 
         $swishPaymentObject = new SwishPaymentObject();
         $swishPaymentObject->setPayment($payment);

--- a/tests/TrustlyPaymentTest.php
+++ b/tests/TrustlyPaymentTest.php
@@ -9,6 +9,7 @@ use SwedbankPay\Api\Service\Trustly\Resource\Request\PaymentPrefillInfo;
 use SwedbankPay\Api\Service\Trustly\Resource\Request\PaymentUrl;
 use SwedbankPay\Api\Service\Trustly\Resource\Request\Payment;
 use SwedbankPay\Api\Service\Trustly\Resource\Request\PaymentObject;
+use SwedbankPay\Api\Service\Payment\Resource\Request\Metadata;
 
 use SwedbankPay\Api\Service\Data\ResponseInterface as ResponseServiceInterface;
 use SwedbankPay\Api\Service\Resource\Data\ResponseInterface as ResponseResourceInterface;
@@ -76,6 +77,9 @@ class TrustlyPaymentTest extends TestCase
         $prices = new PricesCollection();
         $prices->addItem($price);
 
+        $metadata = new Metadata();
+        $metadata->setData('order_id', 'or-123456');
+
         $payment = new Payment();
         $payment->setOperation('Purchase')
             ->setIntent('Sale')
@@ -86,7 +90,8 @@ class TrustlyPaymentTest extends TestCase
             ->setUrls($url)
             ->setPayeeInfo($payeeInfo)
             ->setPrefillInfo($prefillInfo)
-            ->setPrices($prices);
+            ->setPrices($prices)
+            ->setMetadata($metadata);
 
         $paymentObject = new PaymentObject();
         $paymentObject->setPayment($payment);

--- a/tests/VippsPaymentTest.php
+++ b/tests/VippsPaymentTest.php
@@ -2,6 +2,7 @@
 
 use SwedbankPay\Api\Service\Payment\Resource\Collection\PricesCollection;
 use SwedbankPay\Api\Service\Payment\Resource\Collection\Item\PriceItem;
+use SwedbankPay\Api\Service\Payment\Resource\Request\Metadata;
 use SwedbankPay\Api\Service\Payment\Transaction\Resource\Request\TransactionObject;
 use SwedbankPay\Api\Service\Vipps\Request\Purchase;
 use SwedbankPay\Api\Service\Vipps\Resource\Request\PaymentPayeeInfo;
@@ -55,6 +56,9 @@ class VippsPaymentTest extends TestCase
         $prices = new PricesCollection();
         $prices->addItem($price);
 
+        $metadata = new Metadata();
+        $metadata->setData('order_id', 'or-123456');
+
         $payment = new Payment();
         $payment->setOperation('Purchase')
             ->setIntent('Authorization')
@@ -65,7 +69,8 @@ class VippsPaymentTest extends TestCase
             ->setUrls($url)
             ->setPayeeInfo($payeeInfo)
             ->setPrefillInfo($prefillInfo)
-            ->setPrices($prices);
+            ->setPrices($prices)
+            ->setMetadata($metadata);
 
         $vippsPaymentObject = new VippsPaymentObject();
         $vippsPaymentObject->setPayment($payment);


### PR DESCRIPTION
Metadata can be used to store data associated to a payment that can be retrieved later by performing a GET on the payment. Swedbank Pay does not use or process metadata, it is only stored on the payment so it can be retrieved later alongside the payment. An example where metadata might be useful is when several internal systems are involved in the payment process and the payment creation is done in one system and post-purchases take place in another. In order to transmit data between these two internal systems, the data can be stored in metadata on the payment so the internal systems do not need to communicate with each other directly.