### PR TITLE
Restores Response class to allow backwards compatibility

### DIFF
--- a/src/SwedbankPay/Api/Response.php
+++ b/src/SwedbankPay/Api/Response.php
@@ -1,0 +1,239 @@
+<?php
+// phpcs:ignoreFile
+
+namespace SwedbankPay\Api;
+
+use SwedbankPay\Api\Client\Exception;
+
+/**
+ * Response class to handle JSON objects
+ *
+ * @note For backwards compatibility for previous versions
+ * @SuppressWarnings(PHPMD.ExcessivePublicCount)
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ */
+class Response implements \ArrayAccess
+{
+    /**
+     * JSON Body
+     *
+     * @var string
+     */
+    protected $body = '';
+
+    /**
+     * Parsed JSON Body
+     *
+     * @var array|mixed
+     */
+    protected $object = [];
+
+    /**
+     * Response constructor.
+     *
+     * @param $body
+     *
+     * @throws Exception
+     */
+    public function __construct($body)
+    {
+        $this->body   = $body;
+        $this->object = json_decode($body, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new Exception('Unable to decode JSON.');
+        }
+    }
+
+    /**
+     * Get Source Body
+     *
+     * @return string
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * To Array
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->object;
+    }
+
+    /**
+     * To JSON
+     *
+     * @param int $options
+     *
+     * @return false|string
+     */
+    public function toJson($options = 0)
+    {
+        return json_encode($this->object, $options);
+    }
+
+    /**
+     * To String
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->toJson();
+    }
+
+    /**
+     * Set Value
+     *
+     * @param $key
+     * @param $value
+     */
+    public function __set($key, $value)
+    {
+        $this->object[$key] = $value;
+    }
+
+    /**
+     * Get Value
+     *
+     * @param $key
+     *
+     * @return mixed|null
+     */
+    public function __get($key)
+    {
+        return isset($this->object[$key]) ? $this->object[$key] : null;
+    }
+
+    /**
+     * Is Set Value
+     *
+     * @param $key
+     *
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        return isset($this->object[$key]);
+    }
+
+    /**
+     * Unset
+     *
+     * @param $key
+     */
+    public function __unset($key)
+    {
+        unset($this->object[$key]);
+    }
+
+    /**
+     * Implementation of \ArrayAccess::offsetSet()
+     *
+     * @param string $offset
+     * @param mixed $value
+     * @return void
+     * @link http://www.php.net/manual/en/arrayaccess.offsetset.php
+     * @SuppressWarnings(PHPMD.ElseExpression)
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            $this->object[] = $value;
+        } else {
+            $this->object[$offset] = $value;
+        }
+    }
+
+    /**
+     * Implementation of \ArrayAccess::offsetExists()
+     *
+     * @param string $offset
+     * @return bool
+     * @link http://www.php.net/manual/en/arrayaccess.offsetexists.php
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->object[$offset]);
+    }
+
+    /**
+     * Implementation of \ArrayAccess::offsetUnset()
+     *
+     * @param string $offset
+     * @return void
+     * @link http://www.php.net/manual/en/arrayaccess.offsetunset.php
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->object[$offset]);
+    }
+
+    /**
+     * Implementation of \ArrayAccess::offsetGet()
+     *
+     * @param string $offset
+     * @return mixed
+     * @link http://www.php.net/manual/en/arrayaccess.offsetget.php
+     */
+    public function offsetGet($offset)
+    {
+        return isset($this->object[$offset]) ? $this->object[$offset] : null;
+    }
+
+    /**
+     * Set/Get attribute wrapper
+     *
+     * @param $method
+     * @param $arguments
+     *
+     * @return mixed
+     * @throws Exception
+     */
+    public function __call($method, $arguments)
+    {
+        $key = lcfirst(mb_substr($method, 3, mb_strlen($method, 'UTF-8'), 'UTF-8'));
+        switch (mb_substr($method, 0, 3, 'UTF-8')) {
+            case 'get':
+                return $this->__get($key);
+            case 'set':
+                return $this->__set($key, $arguments[0]);
+            case 'uns':
+                return $this->__unset($key);
+            case 'has':
+                return $this->__isset($key);
+        }
+
+        throw new Exception(sprintf('Invalid method %s::%s', get_class($this), $method));
+    }
+
+    /**
+     * Extract operation value from operations list
+     *
+     * @param string $rel
+     * @param bool   $single
+     *
+     * @return bool|string|array
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     */
+    public function getOperationByRel($rel, $single = true)
+    {
+        $operations = isset($this->object['operations']) ? $this->object['operations'] : [];
+        $operation  = array_filter($operations, function ($value, $key) use ($rel) {
+            return (is_array($value) && $value['rel'] === $rel);
+        }, ARRAY_FILTER_USE_BOTH);
+
+        if (count($operation) > 0) {
+            $operation = array_shift($operation);
+
+            return $single ? $operation['href'] : $operation;
+        }
+
+        return false;
+    }
+}

--- a/src/SwedbankPay/Api/Response.php
+++ b/src/SwedbankPay/Api/Response.php
@@ -221,6 +221,7 @@ class Response implements \ArrayAccess
      * @return bool|string|array
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function getOperationByRel($rel, $single = true)
     {

--- a/src/SwedbankPay/Api/Response.php
+++ b/src/SwedbankPay/Api/Response.php
@@ -11,6 +11,7 @@ use SwedbankPay\Api\Client\Exception;
  * @note For backwards compatibility for previous versions
  * @SuppressWarnings(PHPMD.ExcessivePublicCount)
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings(PHPMD.TooManyMethods)
  */
 class Response implements \ArrayAccess
 {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use SwedbankPay\Api\Client\Exception;
+use SwedbankPay\Api\Response;
+
+class ResponseTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var string
+     */
+    protected $callbackResponse;
+
+    public function setUp(): void
+    {
+        $this->callbackResponse =
+            '{
+                "payment": {
+                    "id": "/psp/creditcard/payments/1a23bc45-6789-0a12-ab12-1a23bc45de67",
+                    "number": 40000000123
+                },
+                "transaction": {
+                    "id": "/psp/creditcard/payments/1a23bc45-6789-0a12-ab12-1a23bc45de67/authorizations/1a23bc45-6789-0a12-ab12-1ab2c3def456",
+                    "number": 40000000456
+                }
+            }';
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testResponseInstance()
+    {
+        $response = new Response($this->callbackResponse);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals($this->callbackResponse, $response->getBody());
+        $this->assertEquals(json_decode($this->callbackResponse, true), $response->toArray());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testOffsetGetReturnsFieldFromJson()
+    {
+        $responseObject = json_decode($this->callbackResponse, true);
+        $transaction = $responseObject['transaction'];
+
+        $response = new Response($this->callbackResponse);
+
+        $this->assertEquals($transaction, $response->offsetGet('transaction'));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testOffsetGetReturnsNullForNonExistingField()
+    {
+        $response = new Response($this->callbackResponse);
+
+        $this->assertEquals(null, $response->offsetGet('authorization'));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testResponseThrowsExceptionWithEmptyBody()
+    {
+        $this->expectException(Exception::class);
+
+        $response = new Response('');
+        $this->assertInstanceOf(Response::class, $response);
+    }
+}


### PR DESCRIPTION
This class existed in `v4.0.0-beta.3`. But on the next release `v4.0.0-beta.4`, it was removed along with `Client.php` file. Since **SwedbankPay_Payments** module is relying on `Response` class, the functionality of this class does not exist anywhere else & we have some merchants using the module, we should keep this class in order to support backwards compatibility.