### PR TITLE
Suppress PHP warnings on is_readable

### DIFF
--- a/src/SwedbankPay/Api/Client/Client.php
+++ b/src/SwedbankPay/Api/Client/Client.php
@@ -8,6 +8,7 @@ use SwedbankPay\Api\Client\Resource\Client as ClientResource;
  * Class Client
  * @package SwedbankPay\Api\Client
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
+ * @SuppressWarnings(PHPMD.ErrorControlOperator)
  */
 class Client extends ClientResource
 {


### PR DESCRIPTION
To have no warnings like this
Warning: is_readable(): open_basedir restriction in effect. File(/etc/pki/tls/certs/ca-bundle.crt) is not within the allowed path(s):