### PR TITLE
Fix findFileByNamespace function for Windows

### DIFF
--- a/src/SwedbankPay/Api/Service/ResourceFactory.php
+++ b/src/SwedbankPay/Api/Service/ResourceFactory.php
@@ -316,7 +316,7 @@ class ResourceFactory
 
     private function findFileByNamespace($resourceFqcn)
     {
-        $basePath = str_replace(str_replace('\\', '/', __NAMESPACE__), '', __DIR__);
+        $basePath = str_replace('\\', '/', str_replace(__NAMESPACE__, '', __DIR__));
         return file_exists($basePath . str_replace('\\', '/', $resourceFqcn) . '.php');
     }
 


### PR DESCRIPTION
I think here is a "typo".
It might work on Linux and iOS systems, but is wrong on Windows.

We should first do str_replace to 
str_replace(__NAMESPACE__, '', __DIR__) 
and then replacing `\\` to `/`
not other way around