### PR TITLE
Use null coalesce to avoid null warning.

### DIFF
--- a/src/SwedbankPay/Api/Service/Response.php
+++ b/src/SwedbankPay/Api/Service/Response.php
@@ -54,7 +54,7 @@ class Response extends AbstractSimpleDataObject implements ResponseInterface
             $serviceBaseName .= '\\' . $subServiceBaseName;
         }
 
-        if (class_exists($this->getRequestService()->getResponseResourceFQCN())) {
+        if (class_exists($this->getRequestService()->getResponseResourceFQCN() ?? '')) {
             $responseResourceFCQN = $this->getRequestService()->getResponseResourceFQCN();
             $responseResource = $this->resourceFactory->createFromFqcn($serviceBaseName, $responseResourceFCQN, $data);
             $this->setResponseResource($responseResource);


### PR DESCRIPTION
Passing null in place of a string yields a deprecated warning in PHP 8, so we use ?? '' to get an empty string in place a null value.