### PR TITLE
Fix deprecated warning in PHP 8

### DIFF
--- a/src/SwedbankPay/Api/Service/Response.php
+++ b/src/SwedbankPay/Api/Service/Response.php
@@ -54,7 +54,9 @@ class Response extends AbstractSimpleDataObject implements ResponseInterface
             $serviceBaseName .= '\\' . $subServiceBaseName;
         }
 
-        if (class_exists($this->getRequestService()->getResponseResourceFQCN())) {
+        if ($this->getRequestService()->getResponseResourceFQCN() &&
+            class_exists($this->getRequestService()->getResponseResourceFQCN())
+        ) {
             $responseResourceFCQN = $this->getRequestService()->getResponseResourceFQCN();
             $responseResource = $this->resourceFactory->createFromFqcn($serviceBaseName, $responseResourceFCQN, $data);
             $this->setResponseResource($responseResource);


### PR DESCRIPTION
There's another solution to fix issue described in #101. Closes #101. Fixes #105.